### PR TITLE
Bug fixes relating to unwrapping arrays

### DIFF
--- a/easyxml-ts.js
+++ b/easyxml-ts.js
@@ -40,7 +40,6 @@ var EasyXml = function() {
     self.config = {
         singularizeChildren: true,
         underscoreAttributes: true,
-        deleteParentAfterUnwrap: true,
         underscoreChar: '_',
         rootElement: 'response',
         dateFormat: 'ISO', // ISO = ISO8601, SQL = MySQL Timestamp, JS = (new Date).toString()
@@ -89,7 +88,7 @@ var EasyXml = function() {
                 if (!isAttribute(self))
                     el = subElement(parentXmlNode, key);
 
-                if (!self.config.singularizeChildren && typeof parentXmlNode === 'object' && typeof child === 'object') {
+                if ((!self.config.singularizeChildren && !self.config.unwrappedArrays) && typeof parentXmlNode === 'object' && typeof child === 'object') {
                     for (var key in child) {
                         if (typeof child[key] === 'object') {
                             parseChildElement(el, child[key]);
@@ -148,12 +147,8 @@ var EasyXml = function() {
                     // if unwrapped arrays, the initial child element has been consumed:
                     if (self.config.unwrappedArrays === true) 
                     {
+                        parentXmlNode.delItem(parentXmlNode._children.indexOf(el));
                         el = undefined;
-
-                        if(self.config.deleteParentAfterUnwrap === true)
-                        {
-                            parentXmlNode.delItem(parentXmlNode._children.indexOf(el));
-                        }
                     }
                 } else if (typeof child === 'object') {
                     // Object, go deeper


### PR DESCRIPTION
BUG 1 : If 'SingularizeChildren' is set to false and UnwrapEntities is set to true, arrays would never get unwrapped.

Bug 2 : When unwrapping an array, the property that points at the array before the unwrap is not removed from the object after the unwrap. 
