### PR TITLE
Bug Fix: "IncludeNamedElementsOnly" includes attributes and excludes non-named elements only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.log
+.idea

--- a/test/fixtures/schemaNamedElementsOnly.json
+++ b/test/fixtures/schemaNamedElementsOnly.json
@@ -13,6 +13,11 @@
         "many": [
             {"one":{"_id":1, "_":"Uno"}},
             {"two":{"_id":2, "_":"Dos"}}
-        ]
+        ],
+        "_attrs": {
+            "id": "1234",
+            "name": "Deeper"
+        },
+        "_ref": "http://wherever"
     }
 }

--- a/test/fixtures/schemaNamedElementsOnly.xml
+++ b/test/fixtures/schemaNamedElementsOnly.xml
@@ -2,7 +2,7 @@
     <single>
         <single>JustMe</single>
     </single>
-    <deeper>
+    <deeper id="1234" name="Deeper" ref="http://wherever">
         <many>
             <many>
                 <one id="1">Uno</one>

--- a/test/schemaNamedElementsOnlySchema.js
+++ b/test/schemaNamedElementsOnlySchema.js
@@ -18,6 +18,7 @@ module.exports = {
             "Type" : null // specifically no schema fo sub-type
         }
         // the other elements are not specified, and should not appear because "IncludeNamedElementsOnly" is set
+        // but attributes and attribute objects should be output
     }
 
 }


### PR DESCRIPTION
Fix to ensure that attributes and attribute objects are still output when IncludeNamedElementsOnly is set.
For example,

    "_reg": "http://somewhere.com"

or

    "_attrs": {
       "id": "1234",
       "name": "something"
    }

will still make it to the output as attributes, say:

    <element id="1234" name="something" ref="http://somewhere.com">
