### PR TITLE
Added "ValidAttributes" to schema

### DIFF
--- a/test/fixtures/schemaValidAttributes.json
+++ b/test/fixtures/schemaValidAttributes.json
@@ -1,0 +1,32 @@
+{
+    "allAttributes": {
+        "many": [
+            {"one":{"_id":1, "_":"Uno"}},
+            {"two":{"_id":2, "_":"Dos"}}
+        ],
+        "_attrs": {
+            "description": "All included",
+            "id": "1234",
+            "name": "Everything"
+        },
+        "_path": "starting/from/here",
+        "_ref": "http://wherever"
+    },
+
+    "limitedAttributes": {
+        "single": [
+            {"three":{"_id":3, "_":"Tres"}}
+        ],
+        "many": [
+            {"one":{"_id":1, "_":"Uno"}},
+            {"two":{"_id":2, "_":"Dos"}}
+        ],
+        "_attrs": {
+            "description": "Abridged",
+            "id": "1234",
+            "name": "Something"
+        },
+        "_path": "starting/from/there",
+        "_ref": "http://wherever"
+    }
+}

--- a/test/fixtures/schemaValidAttributes.xml
+++ b/test/fixtures/schemaValidAttributes.xml
@@ -1,0 +1,27 @@
+<response>
+    <allAttributes description="All included" id="1234" name="Everything" path="starting/from/here" ref="http://wherever">
+        <many>
+            <many>
+                <one id="1">Uno</one>
+            </many>
+            <many>
+                <two id="2">Dos</two>
+            </many>
+        </many>
+    </allAttributes>
+    <limitedAttributes id="1234" name="Something" path="starting/from/there">
+        <many>
+            <many>
+                <one id="1">Uno</one>
+            </many>
+            <many>
+                <two id="2">Dos</two>
+            </many>
+        </many>
+        <single>
+            <single>
+                <three id="3">Tres</three>
+            </single>
+        </single>
+    </limitedAttributes>
+</response>

--- a/test/schemaValidAttributesSchema.js
+++ b/test/schemaValidAttributesSchema.js
@@ -1,0 +1,32 @@
+module.exports = {
+    "schemaRoot" : {
+        "0" : {
+            "ElementName" : "allAttributes",
+            "Type" : "allRoot"
+        },
+        "1" : {
+            "ElementName" : "limitedAttributes",
+            "Type" : "limitedRoot"
+        }
+    },
+
+    "allRoot" : {
+        // All attributes should appear in output
+        "0" : {
+            "ElementName" : "many",
+            "Type" : null // specifically no schema for sub-type
+        }
+    },
+
+    "limitedRoot" : {
+        // Only the following attributes will appear in output
+        "ValidAttributes": [
+            "id", "name", "path"
+        ],
+        "0" : {
+            "ElementName" : "many",
+            "Type" : null // specifically no schema for sub-type
+        }
+    }
+
+}

--- a/test/tests.js
+++ b/test/tests.js
@@ -9,7 +9,7 @@ var assert  = require("chai").assert,
     easyXML = require("../easyxml-ts.js");
 
 describe("Node EasyXML", function () {
-  var should = {
+    var should = {
         "names"  : "should parse a JSON object into XML",
         "names1" : "should parse a JSON object with attrs into XML",
         "names2" : "should parse a JSON object with attrs and text node into XML",
@@ -25,54 +25,55 @@ describe("Node EasyXML", function () {
         "groupedAttributes" : "should be able to handle grouped attributes",
         "schemaOrder" : "should order output elements based on schema if one is provided",
         "bareArray" : "should be able to convert an array that is not contained in an object",
-        "schemaNamedElementsOnly" : "should output only elements named in schema in the order provided"
-      };
+        "schemaNamedElementsOnly" : "should output only elements named in schema in the order provided",
+        "schemaValidAttributes" : "should output only ValidAttributes if specified in schema"
+    };
 
-  Object.keys(should)
-    .forEach(function(name){
-      it(should[name], function (done) {
-        var config = {};
-        var objectType = undefined;
-        if (name === 'singularizeChildren' || name === 'singularizeChildren2') {
-          config.singularizeChildren = false;
-        } else {
-          config.singularizeChildren = true;
-        }
-        if (name === 'unwrappedArrays') {
-          config.unwrappedArrays = true;
-        } else {
-          config.unwrappedArrays = false;
-        }
+    Object.keys(should)
+        .forEach(function(name){
+            it(should[name], function (done) {
+                var config = {};
+                var objectType = undefined;
+                if (name === 'singularizeChildren' || name === 'singularizeChildren2') {
+                    config.singularizeChildren = false;
+                } else {
+                    config.singularizeChildren = true;
+                }
+                if (name === 'unwrappedArrays') {
+                    config.unwrappedArrays = true;
+                } else {
+                    config.unwrappedArrays = false;
+                }
+                if (name === 'bareArray') {
+                    config.schema = require('./schemaOrderSchema');
+                    objectType = "schemaRoot";
+                } else if (name.indexOf('schema') === 0) {
+                    var filePath = './' + name + 'Schema';
+                    config.schema = require(filePath);
+                    objectType = "schemaRoot";
+                } else {
+                    config.schema = undefined;
+                }
 
-        if (name === 'schemaOrder' || name === 'bareArray') {
-          config.schema = require('./schemaOrderSchema');
-          objectType = "schemaRoot";
-        } else if (name === 'schemaNamedElementsOnly') {
-          config.schema = require('./schemaNamedElementsOnlySchema');
-          objectType = 'schemaRoot';
-        } else {
-          config.schema = undefined;
-        }
+                easyXML.configure(config);
 
-        easyXML.configure(config);
+                var file = __dirname + "/fixtures/" + name;
 
-        var file = __dirname + "/fixtures/" + name;
+                fs.readFile(file + ".xml", "UTF-8", function (err, data) {
+                    if (err) {
+                        throw err;
+                    }
 
-        fs.readFile(file + ".xml", "UTF-8", function (err, data) {
-          if (err) {
-            throw err;
-          }
+                    var json = require(file + ".json");
+                    if (name === "undefined") {
+                        json.undefinedz = undefined;
+                    }
 
-          var json = require(file + ".json");
-          if (name === "undefined") {
-            json.undefinedz = undefined;
-          }
+                    assert.equal(easyXML.render(json, objectType), data, "EasyXML should create the correct XML from a JSON data structure.");
+                    assert.strictEqual(easyXML.render(json, objectType), data, "EasyXML should create the correct XML from a JSON data structure.");
 
-          assert.equal(easyXML.render(json, objectType), data, "EasyXML should create the correct XML from a JSON data structure.");
-          assert.strictEqual(easyXML.render(json, objectType), data, "EasyXML should create the correct XML from a JSON data structure.");
-
-          done();
+                    done();
+                });
+            });
         });
-      });
-    });
 });


### PR DESCRIPTION
Any element node can have a "ValidAttributes" property which is an array of strings. If specified then only attributes appearing in the array will make it to the output for that element.

For example, the following limits attributes on the <limitRoot> element to id, name and path.

    "limitedRoot" : {
        // Only the following attributes will appear in output
        "ValidAttributes": [
            "id", "name", "path"
        ],
        "0" : {
            "ElementName" : "many",
            "Type" : null // specifically no schema for sub-type
        }
    }