### PR TITLE
singulariseChildren should be respected when unwrapping arrays

### DIFF
--- a/easyxml-ts.js
+++ b/easyxml-ts.js
@@ -100,7 +100,7 @@ var EasyXml = function ()
         var remainingKeys;
         if (isEnumerable(parentObjectNode)) {
             remainingKeys = Object.keys(parentObjectNode);
-        } else { 
+        } else {
             remainingKeys = [];
         }
 
@@ -226,7 +226,7 @@ var EasyXml = function ()
             }
         } else if (typeof child === 'object' && child.constructor && child.constructor.name && child.constructor.name === 'Array') {
             // Array
-            var subElementName = inflect.singularize(key);
+            var subElementName = self.config.unwrappedArrays && !self.config.singularizeChildren ? key : inflect.singularize(key);
 
             for (var key2 in child) {
                 // if unwrapped arrays, make new subelements on the parent.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "easyxml-ts",
     "preferGlobal": false,
-    "version": "0.0.24",
+    "version": "0.0.25",
     "main": "easyxml-ts.js",
     "author": "Thomas Hunter <tlhunter@gmail.com>",
     "description": "A configurable object to XML converter, with Typescript headers",


### PR DESCRIPTION
When arrays where been unwrapped inflect was always being invoked even where singulariseChildren was set to false.
Note: This version has been published to NPM
